### PR TITLE
Added Package.swift for SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "GAppAuth",
+    platforms: [
+        .macOS(.v10_11),
+        .iOS(.v11)
+    ],
+    products: [
+        .library(name: "GAppAuth-iOS", targets: ["GAppAuth-iOS"]),
+        .library(name: "GAppAuth-macOS", targets: ["GAppAuth-macOS"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/google/GTMAppAuth.git", from: "1.0.0"),
+        .package(url: "https://github.com/openid/AppAuth-iOS.git", from: "1.0.0")
+    ],
+    targets: [
+        .target(name: "GAppAuth-iOS", dependencies: ["GTMAppAuth", "AppAuth"], path: "Sources/iOS"),
+        .target(name: "GAppAuth-macOS", dependencies: ["GTMAppAuth", "AppAuth"], path: "Sources/macOS")
+    ]
+)


### PR DESCRIPTION
This adds a Package.swift file which makes the framework installable in iOS and macOS projects, as per issue #16. The file is pretty basic and exports 2 products: `GAppAuth-iOS` and `GAppAuth-macOS`. I haven't yet found a more elegant way to just export `GAppAuth` and have it compile for whatever platform is required, but this works fine for now.